### PR TITLE
Docker container requires port number as argument, and not "https"

### DIFF
--- a/main/index.md
+++ b/main/index.md
@@ -52,7 +52,7 @@ Assuming you have
 just run this command from a terminal:
 
 ```
-docker run --rm -d -p 31337:31337 yamlio/yaml-play-sandbox:{{site.sandbox_version}} https
+docker run --rm -d -p 31337:31337 yamlio/yaml-play-sandbox:{{site.sandbox_version}} 31337
 ```
 
 This will start a local YAML Playground Sandbox Server, and your playgrounds


### PR DESCRIPTION
Running the docker container as instructed [on the homepage](https://play.yaml.io/main/#setting-up-a-local-sandbox) exits immediately. Running without `-d` reveals the problem:

```
Traceback (most recent call last):
  File "/bin/play-sandbox", line 85, in <module>
    app.run(
  File "/usr/lib/python3.9/site-packages/flask/app.py", line 905, in run
    port = int(port)
ValueError: invalid literal for int() with base 10: 'https'
```
So the parameter should be `31337` instead of `https`.

The instructions in the sandbox popup are correct.